### PR TITLE
Fix Early Return in create_index Function

### DIFF
--- a/UFC/vector/ingest.py
+++ b/UFC/vector/ingest.py
@@ -278,7 +278,7 @@ def add_vector(index, values, metadata):
     DOC_IDX += 1
 
 def create_index():
-    return None
+    # return None
     VECTOR_DIMENSIONS = 1536
 
     pc = Pinecone(api_key=os.getenv("PINECONE_TOKEN"))


### PR DESCRIPTION
**Description:**
This pull request addresses an issue in the create_index function within the ingest.py script, where an early return statement prevented the function from executing its intended purpose of creating and returning a new Pinecone index.

**Changes Made:**
Commented out the return None line in the create_index function to allow the function to proceed with creating and initializing the Pinecone index.

**Purpose of the Change:**
The existing code returned None immediately upon calling create_index, which resulted in an AttributeError when attempting to use the upsert method on a NoneType object. This change ensures that an index object is properly created and returned, allowing subsequent calls to upsert to execute correctly.

**Testing:**
The correction has been tested locally, and after making this change, the script was executed successfully without any errors related to the index creation.